### PR TITLE
Add upgrade image for v1.17.0+k3s.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,101 @@
+---
+kind: pipeline
+name: amd64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: docker-publish
+  image: plugins/docker
+  settings:
+    dockerfile: Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/k3s-upgrade"
+    username:
+      from_secret: docker_username
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+
+- name: docker-publish
+  image: plugins/docker
+  build_args:
+    - ARCH=-arm64
+  settings:
+    dockerfile: Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/k3s-upgrade"
+    username:
+      from_secret: docker_username
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: arm
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+
+- name: docker-publish
+  image: plugins/docker
+  build_args:
+    - ARCH=-armhf
+  settings:
+    dockerfile: package/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/k3s-upgrade"
+    username:
+      from_secret: docker_username
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.swp
+/.idea
+/.*_history
+/.viminfo
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.10
+
+ARG ARCH=
+ARG VERSION="v1.17.0+k3s.1"
+
+ENV K3S_RELEASE https://github.com/rancher/k3s/releases/download/${VERSION}/k3s${ARCH}
+
+RUN wget -O /bin/k3s${ARCH} ${K3S_RELEASE}
+RUN chmod +x /bin/k3s${ARCH}
+COPY scripts/upgrade.sh /bin/upgrade.sh
+
+ENTRYPOINT ["/bin/upgrade.sh"]

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,95 @@
+#!/bin/sh -xe
+
+info()
+{
+    echo '[INFO] ' "$@"
+}
+
+fatal()
+{
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+verify_system() {
+    if ! type pgrep; then
+      fatal 'Can not find pgrep tool'
+    fi
+    if [ -x /host/sbin/openrc-run ]; then
+        HAS_OPENRC=true
+        return
+    fi
+    if [ -d /host/run/systemd ]; then
+        HAS_SYSTEMD=true
+        return
+    fi
+    fatal 'Can not find systemd or openrc to use as a process supervisor for k3s'
+}
+
+setup_verify_arch() {
+    if [ -z "$ARCH" ]; then
+        ARCH=$(uname -m)
+    fi
+    case $ARCH in
+        amd64)
+            ARCH=amd64
+            SUFFIX=
+            ;;
+        x86_64)
+            ARCH=amd64
+            SUFFIX=
+            ;;
+        arm64)
+            ARCH=arm64
+            SUFFIX=-${ARCH}
+            ;;
+        aarch64)
+            ARCH=arm64
+            SUFFIX=-${ARCH}
+            ;;
+        arm*)
+            ARCH=arm
+            SUFFIX=-${ARCH}hf
+            ;;
+        *)
+            fatal "Unsupported architecture $ARCH"
+    esac
+}
+
+get_k3s_process_info() {
+  K3S_PID=$(pgrep k3s-)
+  if [ -z "$K3S_PID" ]; then
+    fatal "K3s is not running on this server"
+  fi
+  #K3S_BIN_PATH=$(ls  -l /host/proc/${K3S_PID}/exe | awk -F '-> ' '{print $2}')
+  K3S_BIN_PATH=$(cat /host/proc/${K3S_PID}/cmdline | awk '{print $1}' | head -n 1)
+  if [ -z "$K3S_BIN_PATH" ]; then
+    fatal "Failed to fetch the k3s binary path from process $K3S_PID"
+  fi
+  return
+}
+
+replace_binary() {
+  NEW_BINARY="/bin/k3s${SUFFIX}"
+  if [ ! -f $NEW_BINARY ]; then
+    fatal "The new binary $NEW_BINARY doesn't exist"
+  fi
+  FULL_BIN_PATH="host/$K3S_BIN_PATH"
+  cp $NEW_BINARY $FULL_BIN_PATH
+  info "K3s binary has been replaced successfully"
+  return
+}
+
+kill_k3s_process() {
+    # the script sends SIGTERM to the process and let the supervisor
+    # to automatically restart k3s with the new version
+    kill -SIGTERM $K3S_PID
+}
+
+{
+  verify_system
+  setup_verify_arch
+  get_k3s_process_info
+  replace_binary
+  kill_k3s_process
+}


### PR DESCRIPTION
The PR adds the following:

- Docker image that run upgrade script to replace the k3s binary with the binary included in the image
- drone file to build and publish the corresponding images 