### PR TITLE
Remove Arch specific code from the upgrader

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,10 @@ steps:
       path: /var/run/docker.sock
 - name: docker-publish
   image: plugins/docker
+  build_args_from_env:
+    - DRONE_TAG
+  build_args:
+    - ARCH=
   settings:
     dockerfile: Dockerfile
     password:
@@ -55,6 +59,8 @@ steps:
       path: /var/run/docker.sock
 - name: docker-publish
   image: plugins/docker
+  build_args_from_env:
+    - DRONE_TAG
   build_args:
     - ARCH=-arm64
   settings:
@@ -96,6 +102,8 @@ steps:
       path: /var/run/docker.sock
 - name: docker-publish
   image: plugins/docker
+  build_args_from_env:
+    - DRONE_TAG
   build_args:
     - ARCH=-arm
   settings:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM alpine:3.10
 
 ARG ARCH=
-ARG VERSION="v1.17.2+k3s1"
 
-ENV K3S_RELEASE https://github.com/rancher/k3s/releases/download/${VERSION}/k3s${ARCH}
+ENV K3S_RELEASE https://github.com/rancher/k3s/releases/download/${DRONE_TAG}/k3s${ARCH}
 
-RUN wget -O /bin/k3s${ARCH} ${K3S_RELEASE}
-RUN chmod +x /bin/k3s${ARCH}
+RUN wget -O /bin/k3s ${K3S_RELEASE}
+RUN chmod +x /bin/k3s
 COPY scripts/upgrade.sh /bin/upgrade.sh
 
 ENTRYPOINT ["/bin/upgrade.sh"]


### PR DESCRIPTION
https://github.com/rancher/k3s/issues/1393

- Remove Arch specific code and verify system
- Use DRONE_TAG for the version to automate the process
- Remove k3d comparison code
  - exception: (still need to check if the PID is 1 because the first process cmdline in k3s is /dev/init -- /bin/k3s)
