### PR TITLE
Add wait for master logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM alpine:3.10
 
 ARG ARCH=
+ARG DRONE_TAG=
+ARG KUBECTL_VERSION=
 
 ENV K3S_RELEASE https://github.com/rancher/k3s/releases/download/${DRONE_TAG}/k3s${ARCH}
 ENV K3S_RELEASE_CHECKSUM https://github.com/rancher/k3s/releases/download/${DRONE_TAG}/sha256sum${ARCH}.txt
 
-RUN wget -O /opt/k3s ${K3S_RELEASE}
+RUN apk add -U jq curl
+RUN curl -L -o /opt/k3s ${K3S_RELEASE}
 RUN chmod +x /opt/k3s
 COPY scripts/upgrade.sh /bin/upgrade.sh
 
 ENTRYPOINT ["/bin/upgrade.sh"]
+CMD ["upgrade"]

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -64,9 +64,30 @@ check_hash(){
     fi
 }
 
-{
+prepare() {
+  KUBECTL_BIN="/opt/k3s kubectl"
+  MASTER_PLAN=${1}
+  if [ -z "$MASTER_PLAN" ]; then
+    fatal "Master Plan name is not passed to the prepare step. Exiting"
+  fi
+  NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+  # make sure master plan does exist
+  ${KUBECTL_BIN} get plan $MASTER_PLAN -n $NAMESPACE &>/dev/null || fatal "master plan $MASTER_PLAN doesn't exist"
+  while true; do
+    NUM_NODES=$(${KUBECTL_BIN} get plan $MASTER_PLAN -n $NAMESPACE -o json | jq '.status.applying | length')
+    if [ "$NUM_NODES" == "0" ]; then
+      break
+    fi
+    info "Waiting for all master nodes to be upgraded"
+    sleep 5
+  done
+}
+
+upgrade() {
   check_hash
   get_k3s_process_info
   replace_binary
   kill_k3s_process
 }
+
+"$@"


### PR DESCRIPTION
Fixes #8 

The worker plan can have prepare spec to wait for master plan to finish its work:

```
---
apiVersion: upgrade.cattle.io/v1
kind: Plan
metadata:
  name: k3s-worker-plan
  namespace: system-upgrade
spec:
  concurrency: 1
  version: v1.17.2-k3s1
  # The prepare init container is run before cordon/drain which is run before the upgrade container.
  # Shares the same format as the `upgrade` container
  prepare:
     image: rancher/k3s-upgrade:latest
     args: ["prepare","k3s-master-plan"]
  nodeSelector:
    matchExpressions:
    - {key: k3s-worker-upgrade, operator: Exists}
  serviceAccountName: system-upgrade
  drain:
    force: true
  upgrade:
    image: rancher/k3s-upgrade
```